### PR TITLE
Feature/optimizing scrape params

### DIFF
--- a/lib/etl/scrape.js
+++ b/lib/etl/scrape.js
@@ -2,18 +2,9 @@ import {GAMER_MATCH_TABLE, GAMER_TABLE, MATCH_TABLE, MIN_MAX_TIMESTAMPS_VIEW} fr
 import WarzoneMapper from './mapper';
 
 import Bluebird from 'bluebird';
-import {generateTimestampList, getMinAndMaxTimestamps, insertIntoDatabase, queryDatabase} from './utils';
+import {generateTimestampList, getMinAndMaxTimestamps, insertIntoDatabase, queryDatabase, sleep} from './utils';
 
 import apiLib from 'call-of-duty-api';
-
-
-function sleep(milliseconds) {
-    const date = Date.now();
-    let currentDate = null;
-    do {
-        currentDate = Date.now();
-    } while (currentDate - date < milliseconds);
-}
 
 const API = apiLib({platform: "xbl", ratelimit: {maxRequests: 1, perMilliseconds: 10000, maxRPS: 1}});
 
@@ -60,7 +51,7 @@ function getMatchDetails(object, api) {
     return Bluebird.mapSeries(timestampList, (item) => {
         return api.MWcombatwzdate(object.gamer.username, item.start, item.end, object.gamer.platform).then((output) => {
             let matches = output.matches || [];
-            sleep(5*1000)
+            sleep(7*1000)
             console.log(item);
             let mappedMatches = matches.map(WarzoneMapper.mapMatch);
             let matchPromises = mappedMatches.map((m) => {
@@ -108,5 +99,5 @@ function run() {
 }
 
 
-// run();
-executePipeline({username: '', platform: 'xbl'})
+//run();
+executePipeline({username: 'fieldpipe', platform: 'xbl'})

--- a/lib/etl/scrape.js
+++ b/lib/etl/scrape.js
@@ -2,7 +2,7 @@ import {GAMER_MATCH_TABLE, GAMER_TABLE, MATCH_TABLE, MIN_MAX_TIMESTAMPS_VIEW} fr
 import WarzoneMapper from './mapper';
 
 import Bluebird from 'bluebird';
-import {generateTimestampList, getMinAndMaxTimestamps, insertIntoDatabase, queryDatabase, sleep} from './utils';
+import {insertIntoDatabase, getTimestampList, queryDatabase, sleep} from './utils';
 
 import apiLib from 'call-of-duty-api';
 
@@ -21,23 +21,19 @@ function getGamer(queryGamer, api) {
 
 function getMatches(gamer, api) {
     return api.MWfullcombatwz(gamer.username, gamer.platform).then((output) => {
-        console.log(output);
         return queryDatabase(MIN_MAX_TIMESTAMPS_VIEW, {query_username: gamer.username}).then((data) => {
             let queriedTimestamps = data[0];
-            let timestamps = getMinAndMaxTimestamps(output, 'timestamp');
-            console.log(timestamps);
+            let timestampList = getTimestampList(output, 'timestamp');
             let returnObject = {
                 gamer: gamer,
                 gameCount: output.length,
-                lastTimestamp: timestamps.max,
-                firstTimestamp: timestamps.min
+                timestampList: timestampList
             };
-
             if (queriedTimestamps && !BACKFILL_ALL_DATA) {
-                returnObject.gameCount = returnObject.gameCount - queriedTimestamps.game_count;
-                returnObject.firstTimestamp = parseInt(queriedTimestamps.last_timestamp) * 1000;
+                returnObject.timestampList = returnObject.timestampList.filter(function(item){
+                    return item.end > parseInt(queriedTimestamps.last_timestamp) * 1000;
+                })
             }
-
             return returnObject;
         })
     }).catch((err) => {
@@ -46,7 +42,7 @@ function getMatches(gamer, api) {
 }
 
 function getMatchDetails(object, api) {
-    let timestampList = generateTimestampList(object);
+    let timestampList = object.timestampList
     let queryGamer = object.gamer;
     console.log("getting match details for: " + JSON.stringify(queryGamer))
     return Bluebird.mapSeries(timestampList, (item) => {
@@ -54,7 +50,6 @@ function getMatchDetails(object, api) {
             let matches = output.matches || [];
             sleep(7*1000)
             console.log('Num matches for interval:' + matches.length);
-            console.log(item);
             let mappedMatches = matches.map(WarzoneMapper.mapMatch);
             let matchPromises = mappedMatches.map((m) => {
                 return insertIntoDatabase(m, MATCH_TABLE)
@@ -68,16 +63,6 @@ function getMatchDetails(object, api) {
     });
 }
 
-function getGamerFriends(gamer) {
-    return API.login(EMAIL, PASSWORD).then((response, api) => {
-        return API.MWfriends(gamer.username, gamer.platform).then((friends) => {
-            return Bluebird.all(friends.map(WarzoneMapper.mapGamer).map((friend) => insertIntoDatabase(friend, GAMER_TABLE)
-                    )
-            )
-        })
-    });
-}
-
 function executePipeline(gamer) {
     return API.login(EMAIL, PASSWORD).then((response, api) => {
         return getGamer(gamer, API)
@@ -87,8 +72,8 @@ function executePipeline(gamer) {
     });
 }
 
-function run() {
-    queryDatabase(GAMER_TABLE, {platform: 'xbl'}).then((gamers) => {
+function refreshPlatform(platform) {
+    queryDatabase(GAMER_TABLE, {platform: platform}).then((gamers) => {
         return Bluebird.mapSeries(gamers, (gamer) => {
             return executePipeline(gamer).then(success => {
                 console.log("finished stats for gamer" + JSON.stringify(gamer));
@@ -101,5 +86,5 @@ function run() {
 }
 
 
-//run();
-executePipeline({username: 'Stormbane#1193', platform: 'battle'})
+//refreshPlatform('battle')
+//executePipeline({username: 'EcZachly', platform: 'xbl'})

--- a/lib/etl/scrape.js
+++ b/lib/etl/scrape.js
@@ -21,10 +21,11 @@ function getGamer(queryGamer, api) {
 
 function getMatches(gamer, api) {
     return api.MWfullcombatwz(gamer.username, gamer.platform).then((output) => {
+        console.log(output);
         return queryDatabase(MIN_MAX_TIMESTAMPS_VIEW, {query_username: gamer.username}).then((data) => {
             let queriedTimestamps = data[0];
             let timestamps = getMinAndMaxTimestamps(output, 'timestamp');
-
+            console.log(timestamps);
             let returnObject = {
                 gamer: gamer,
                 gameCount: output.length,
@@ -52,6 +53,7 @@ function getMatchDetails(object, api) {
         return api.MWcombatwzdate(object.gamer.username, item.start, item.end, object.gamer.platform).then((output) => {
             let matches = output.matches || [];
             sleep(7*1000)
+            console.log('Num matches for interval:' + matches.length);
             console.log(item);
             let mappedMatches = matches.map(WarzoneMapper.mapMatch);
             let matchPromises = mappedMatches.map((m) => {
@@ -100,4 +102,4 @@ function run() {
 
 
 //run();
-executePipeline({username: 'fieldpipe', platform: 'xbl'})
+executePipeline({username: 'Stormbane#1193', platform: 'battle'})

--- a/lib/etl/utils.js
+++ b/lib/etl/utils.js
@@ -5,6 +5,16 @@ export function queryDatabase(table, query){
     });
 }
 
+
+
+export function sleep(milliseconds) {
+    const date = Date.now();
+    let currentDate = null;
+    do {
+        currentDate = Date.now();
+    } while (currentDate - date < milliseconds);
+}
+
 export function generateTimestampList(object) {
     let WARZONE_MAX_GAMEREQUESTS = 20;
     let CLUSTERING_FUDGE_FACTOR = 5;

--- a/lib/etl/utils.js
+++ b/lib/etl/utils.js
@@ -16,12 +16,7 @@ export function sleep(milliseconds) {
 }
 
 export function generateTimestampList(object) {
-    let WARZONE_MAX_GAMEREQUESTS = 20;
-    let CLUSTERING_FUDGE_FACTOR = 5;
-    let totalRequests = Math.ceil(object.gameCount.toFixed(2) / WARZONE_MAX_GAMEREQUESTS);
-    let timeFrame = object.lastTimestamp - object.firstTimestamp;
-    let subNum = Math.ceil(Math.ceil(timeFrame / totalRequests) / CLUSTERING_FUDGE_FACTOR);
-
+    let subNum = 12*60*60*1000
     let workingTimestamp = object.lastTimestamp;
     let timestampList = [];
     if(object.gameCount === 1){
@@ -48,7 +43,7 @@ export function generateTimestampList(object) {
 export function getMinAndMaxTimestamps(output, key) {
     let firstTimestamp = Number.MAX_SAFE_INTEGER;
     let lastTimestamp = 0;
-    output.forEach((match) => {
+    output.filter((match)=> match[key] > 0).forEach((match) => {
         if (match[key] > lastTimestamp) {
             lastTimestamp = match[key];
         }

--- a/lib/etl/utils.js
+++ b/lib/etl/utils.js
@@ -15,47 +15,38 @@ export function sleep(milliseconds) {
     } while (currentDate - date < milliseconds);
 }
 
-export function generateTimestampList(object) {
-    let subNum = 12*60*60*1000
-    let workingTimestamp = object.lastTimestamp;
+export function getTimestampList(output, key) {
+    let currentFirstTimestamp = 0;
+    let currentLastTimestamp = 0;
     let timestampList = [];
-    if(object.gameCount === 1){
-        timestampList.push({
-            start: 0,
-            end: 0
-        })
-    }
-    else{
-        while (workingTimestamp > object.firstTimestamp) {
-            let endTimestamp = workingTimestamp;
-            let startTimestamp = workingTimestamp - subNum;
-            timestampList.push({
-                start: startTimestamp,
-                end: endTimestamp
-            })
-            workingTimestamp = workingTimestamp - subNum;
+    output.sort(function(first, second){
+        return first[key] > second[key]
+    })
+    let filtered = output.filter((match)=> match[key] > 0);
+    filtered.forEach((match, index) => {
+        if(index === 0){
+            currentFirstTimestamp = match[key]
         }
-    }
-    timestampList = timestampList.reverse();
-    return timestampList;
-}
 
-export function getMinAndMaxTimestamps(output, key) {
-    let firstTimestamp = Number.MAX_SAFE_INTEGER;
-    let lastTimestamp = 0;
-    output.filter((match)=> match[key] > 0).forEach((match) => {
-        if (match[key] > lastTimestamp) {
-            lastTimestamp = match[key];
+        if(index > 0 && index % 20 === 0){
+            currentLastTimestamp = match[key]
+            timestampList.push({
+                end: currentFirstTimestamp,
+                start: currentLastTimestamp
+            })
+            currentFirstTimestamp = currentLastTimestamp + 1
         }
-        if (match[key] < firstTimestamp) {
-            firstTimestamp = match[key];
+
+        if(index === filtered.length - 1 && index % 20 !== 0){
+            currentLastTimestamp = match[key]
+            timestampList.push({
+                end: currentFirstTimestamp,
+                start: currentLastTimestamp
+            })
         }
     });
 
-    return {
-        min: firstTimestamp,
-        max: lastTimestamp
-    }
+    return timestampList
 }
 
 export function insertIntoDatabase(data, table){

--- a/lib/model/gamer.js
+++ b/lib/model/gamer.js
@@ -4,7 +4,6 @@ const API = apiLib({platform: "battle", ratelimit: {maxRequests: 2, perMilliseco
 let EMAIL = process.env.WARZONE_EMAIL;
 let PASSWORD = process.env.WARZONE_PASSWORD;
 export function getGamerFromAPI(username, platform) {
-    console.log(username, platform);
     return API.login(EMAIL, PASSWORD).then(() => {
         return API.MWwz(username, platform);
     });

--- a/lib/views/player_stat_summary.sql
+++ b/lib/views/player_stat_summary.sql
@@ -19,6 +19,6 @@ SELECT query_username AS username,
 FROM gamer_matches gm
  JOIN matches_augmented m ON gm.match_id = m.match_id
 
-WHERE m.mode NOT LIKE '%plnd%' AND mode NOT LIKE '%jugg%'  AND mode NOT LIKE '%rmbl%'  AND mode NOT LIKE '%mini%' and mode NOT LIKE '%kingslayer%'
+WHERE m.mode NOT LIKE '%plnd%' AND mode NOT LIKE '%jugg%'  AND mode NOT LIKE '%rmbl%'  AND mode NOT LIKE '%mini%' and mode NOT LIKE '%kingslayer%' AND mode NOT LIKE '%dmz%'
 
 GROUP BY gm.query_username;

--- a/lib/views/teammate_analysis.sql
+++ b/lib/views/teammate_analysis.sql
@@ -12,6 +12,7 @@ WITH source AS (
                        AND gm.match_id = gm2.match_id
                        AND gm.username <> gm2.username
     WHERE mode NOT LIKE '%plnd%' AND mode NOT LIKE '%jugg&'  AND mode NOT LIKE '%rmbl%'  AND mode NOT LIKE '%mini%' and mode NOT LIKE '%kingslayer%'
+      AND mode NOT LIKE '%dmz%'
 
 
 ),
@@ -20,6 +21,8 @@ WITH source AS (
           gm.query_username as shooting_player,
        '(overall)' as helping_player_temp,
         COUNT(DISTINCT gm.match_id)                                                               AS num_matches,
+        CAST(SUM(gm.kills) AS real) / CASE WHEN SUM(gm.deaths) = 0 THEN 1 ELSE SUM(gm.deaths) END AS kdr,
+       CAST(SUM(gm.gulag_kills) AS REAL)/SUM( CASE WHEN gm.gulag_deaths <= 1 THEN gm.gulag_deaths END + gm.gulag_kills) as gulag_win_rate,
        SUM(gm.kills)                                                                             AS total_kills,
        AVG(gm.kills)                                                                             AS avg_kills,
        SUM(gm.damage_done)                                                                             AS total_damage_done,
@@ -38,13 +41,12 @@ WITH source AS (
        AVG(COALESCE(CAST(objective->>'teams_wiped' AS INT), 0))                                                            AS avg_teams_wiped,
        SUM(COALESCE(CAST(objective->>'missions_started' AS INT), 0))                                                       AS total_missions_started,
        AVG(COALESCE(CAST(objective->>'missions_started' AS INT), 0))                                                       AS avg_missions_started,
-       CAST(SUM(gm.kills) AS real) / CASE WHEN SUM(gm.deaths) = 0 THEN 1 ELSE SUM(gm.deaths) END AS kdr,
-       CAST(SUM(gm.gulag_kills) AS REAL)/SUM( CASE WHEN gm.gulag_deaths <= 1 THEN gm.gulag_deaths END + gm.gulag_kills) as gulag_win_rate,
        MIN(start_timestamp)                                                                      AS first_game_time,
        MAX(start_timestamp)                                                                      AS last_game_time
     FROM gamer_matches gm
           JOIN matches_augmented m on gm.match_id = m.match_id
     WHERE mode NOT LIKE '%plnd%' AND mode NOT LIKE '%jugg%'  AND mode NOT LIKE '%rmbl%'  AND mode NOT LIKE '%mini%' and mode NOT LIKE '%kingslayer%'
+          AND mode NOT LIKE '%dmz%'
          GROUP BY shooting_player, helping_player_temp
 
      ),
@@ -54,6 +56,8 @@ WITH source AS (
          gm.query_username AS shooting_player,
        helping_player_temp,
         COUNT(DISTINCT gm.match_id)                                                               AS num_matches,
+        CAST(SUM(gm.kills) AS real) / CASE WHEN SUM(gm.deaths) = 0 THEN 1 ELSE SUM(gm.deaths) END AS kdr,
+       CAST(SUM(gm.gulag_kills) AS REAL)/SUM( CASE WHEN gm.gulag_deaths <= 1 THEN gm.gulag_deaths END + gm.gulag_kills) as gulag_win_rate,
        SUM(gm.kills)                                                                             AS total_kills,
        AVG(gm.kills)                                                                             AS avg_kills,
        SUM(gm.damage_done)                                                                             AS total_damage_done,
@@ -72,8 +76,6 @@ WITH source AS (
        AVG(COALESCE(CAST(objective->>'teams_wiped' AS INT), 0))                                                            AS avg_teams_wiped,
        SUM(COALESCE(CAST(objective->>'missions_started' AS INT), 0))                                                       AS total_missions_started,
        AVG(COALESCE(CAST(objective->>'missions_started' AS INT), 0))                                                       AS avg_missions_started,
-       CAST(SUM(gm.kills) AS real) / CASE WHEN SUM(gm.deaths) = 0 THEN 1 ELSE SUM(gm.deaths) END AS kdr,
-       CAST(SUM(gm.gulag_kills) AS REAL)/SUM( CASE WHEN gm.gulag_deaths <= 1 THEN gm.gulag_deaths END + gm.gulag_kills) as gulag_win_rate,
        MIN(start_timestamp)                                                                      AS first_game_time,
        MAX(start_timestamp)                                                                      AS last_game_time
 FROM source gm

--- a/routes/view_router.js
+++ b/routes/view_router.js
@@ -24,8 +24,6 @@ view_router.get('/gamer/:username', (req, res) => {
         'player_stat_summary':  {query:{username: req.params.username}},
         'teammate_analysis': {query:{shooting_player: req.params.username}}
     };
-    console.log(views);
-
     let promises = Object.keys(views).map((key)=> queryView(key, views[key].query));
 
     return Bluebird.all(promises).then((arrData)=>{
@@ -40,7 +38,7 @@ view_router.get('/gamer/:username', (req, res) => {
         let seoMetadata = {
             title: 'Warzone stats for ' + gamer.username,
             keywords: ['warzone', 'stats', 'kdr', 'gulag wins'],
-            description: 'KDR: ' + gamer.kdr + ' Gulag Win Rate: ' + gamer.gulag_win_rate + '%'
+            description: 'KDR: ' + gamer.kdr + ' Gulag Win Rate: ' + gamer.gulag_win_rate
         };
         res.render('gamer/detail', {gamer: gamer, titleKeys: titleKeys, teammateData: teammateData, seoMetadata: seoMetadata, filterKeys: FILTER_KEYS});
     });


### PR DESCRIPTION
@bbleaptrot @fjaxyu 

This code optimizes the API scrape to account for non-uniformly distributed Warzone games. This will always make the minimum number of requests needed to scrape a user's data. 

The API first returns all the matches in a list. 
But the second details API call only takes in a time frame.

So you sort all the matches by timestamp and generate 20 match timeframe timestamp lists based on the initial API.