### PR TITLE
Feature/gamer relationships

### DIFF
--- a/config/server/nextConfig.ts
+++ b/config/server/nextConfig.ts
@@ -27,6 +27,7 @@ export function generateNextConfig({directory, dev, port}) {
                 WARZONE_PASSWORD: process.env.WARZONE_PASSWORD,
                 WARZONE_RECAPTCHA_SITE_KEY: process.env.WARZONE_RECAPTCHA_SITE_KEY,
                 WARZONE_RECAPTCHA_SECRET_KEY: process.env.WARZONE_RECAPTCHA_SECRET_KEY,
+                NEXT_PUBLIC_WARZONE_RECAPTCHA_SITE_KEY: process.env.WARZONE_RECAPTCHA_SITE_KEY,
                 PORT: port
             },
             api: {

--- a/lib/components/Database/DAO.ts
+++ b/lib/components/Database/DAO.ts
@@ -18,7 +18,7 @@ export async function find(table: string, query?: Record<any, unknown>, options?
 
 
 
-export async function insert(table: string, data: Record<any, unknown>) {
+export async function insert(table: string, data: Record<any, unknown>): Promise<any> {
     return new Promise(async (resolve, reject) => {
         validateTable(table).then(async (isValid) => {
             const db = await database;

--- a/lib/components/GamerMatches/GamerMatchController.ts
+++ b/lib/components/GamerMatches/GamerMatchController.ts
@@ -9,8 +9,6 @@ import {GamerMatchList, RawGamerMatchList} from './GamerMatchTypes';
 
 
 export async function queryGamerMatches(query, options): Promise<GamerMatchList> {
-    console.log('query', query);
-    console.log('options', options);
     return DAO.find(VIEWS.GAMER_MATCHES_AUGMENTED, query, options);
 }
 

--- a/lib/components/GamerRelationships/GamerRelationshipController.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipController.ts
@@ -1,0 +1,17 @@
+import {DAO} from './../Database';
+
+import {TABLES, VIEWS} from '../../constants';
+
+import {GamerRelationshipList} from './GamerRelationshipTypes';
+
+
+//===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
+
+export async function queryGamerRelationships(query, options): Promise<GamerRelationshipList> {
+    return DAO.find(TABLES.GAMER_RELATIONSHIPS, query, options);
+}
+
+
+export default {
+    queryGamerRelationships
+};

--- a/lib/components/GamerRelationships/GamerRelationshipController.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipController.ts
@@ -2,7 +2,8 @@ import {DAO} from './../Database';
 
 import {TABLES, VIEWS} from '../../constants';
 
-import {GamerRelationshipList} from './GamerRelationshipTypes';
+import {GamerRelationshipList, RawGamerRelationship} from './GamerRelationshipTypes';
+import {MetadataService} from '../../../src/components/Metadata';
 
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
@@ -12,6 +13,17 @@ export async function queryGamerRelationships(query, options): Promise<GamerRela
 }
 
 
+
+export async function createGamerRelationship(gamerRelationship: Partial<RawGamerRelationship>): Promise<RawGamerRelationship> {
+    if (!gamerRelationship.metadata) {
+        gamerRelationship.metadata = MetadataService.createNewMetadata();
+    }
+
+    return DAO.insert(TABLES.GAMER_RELATIONSHIPS, gamerRelationship);
+}
+
+
 export default {
-    queryGamerRelationships
+    queryGamerRelationships,
+    createGamerRelationship
 };

--- a/lib/components/GamerRelationships/GamerRelationshipRoutes.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipRoutes.ts
@@ -26,16 +26,8 @@ export async function queryGamerRelationships(req: NextApiRequest, res: NextApiR
     const queryParams = req.query;
 
     let options = {
-        limit: undefined,
-        offset: undefined,
         order: undefined
     };
-
-    options.limit = req.query.limit || 10;
-    delete queryParams.limit;
-
-    options.offset = req.query.offset || 0;
-    delete queryParams.offset;
 
     // @ts-ignore
     options.order = UtilityService.isJson(req.query.order) ? JSON.parse(req.query.order) : null;

--- a/lib/components/GamerRelationships/GamerRelationshipRoutes.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipRoutes.ts
@@ -15,6 +15,7 @@ import TypeService from '../../../src/services/TypeService';
 import UtilityService from '../../../src/services/UtilityService';
 
 import {DEFAULT_ERROR_MESSAGE, STATUS_CODE} from '../../../src/config/CONSTANTS';
+import {RawGamer} from '../../../src/components/gamer/GamerTypes';
 
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
@@ -52,13 +53,40 @@ export async function queryGamerRelationships(req: NextApiRequest, res: NextApiR
         }
     }).catch((error) => {
         console.log('error', error);
-
         responseHandler.handleError(req, res, error, 500);
     });
 }
 
 
 
+export async function createGamerRelationship(req: NextApiRequest, res: NextApiResponse) {
+    const gamerRelationship = req.body.gamerRelationship;
+
+    if (TypeService.isInteger(gamerRelationship.user_id) === false) {
+        responseHandler.handleError(req, res, {message: 'body.gamerRelationship.user_id (Integer) is required'}, 400);
+    } else if (TypeService.isString(gamerRelationship.username, true) === false) {
+        responseHandler.handleError(req, res, {message: 'body.gamerRelationship.username (String) is required'}, 400);
+    } else if (TypeService.isString(gamerRelationship.platform, true) === false) {
+        responseHandler.handleError(req, res, {message: 'body.gamerRelationship.platform (String) is required'}, 400);
+    } else if (GamerRelationshipService.isValidType(gamerRelationship.type) === false) {
+        responseHandler.handleError(req, res, {message: 'body.gamerRelationship.type (String) is required and must be one of the following: ' + JSON.stringify(GamerRelationshipService.getValidTypes())}, 400);
+    } else {
+        GamerRelationshipController.createGamerRelationship(gamerRelationship).then((newGamerRelationship) => {
+            if (newGamerRelationship) {
+                responseHandler.handleResponse(req, res, newGamerRelationship);
+            } else {
+                responseHandler.handleError(req, res, DEFAULT_ERROR_MESSAGE, 500);
+            }
+        }).catch((error) => {
+            console.log('error', error);
+            responseHandler.handleError(req, res, error, 500);
+        });
+    }
+}
+
+
+
 export default {
-    queryGamerRelationships
+    queryGamerRelationships,
+    createGamerRelationship
 };

--- a/lib/components/GamerRelationships/GamerRelationshipRoutes.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipRoutes.ts
@@ -1,0 +1,64 @@
+import {NextApiRequest, NextApiResponse} from 'next';
+
+import responseHandler from './../../../routes/responseHandler';
+
+import {
+    RawGamerRelationship,
+    RawGamerRelationshipList,
+    GamerRelationship,
+    GamerRelationshipList
+} from './GamerRelationshipTypes';
+import GamerRelationshipController from './GamerRelationshipController';
+import GamerRelationshipService from './GamerRelationshipService';
+
+import TypeService from '../../../src/services/TypeService';
+import UtilityService from '../../../src/services/UtilityService';
+
+import {DEFAULT_ERROR_MESSAGE, STATUS_CODE} from '../../../src/config/CONSTANTS';
+
+
+//===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
+
+
+
+export async function queryGamerRelationships(req: NextApiRequest, res: NextApiResponse) {
+    const queryParams = req.query;
+
+    let options = {
+        limit: undefined,
+        offset: undefined,
+        order: undefined
+    };
+
+    options.limit = req.query.limit || 10;
+    delete queryParams.limit;
+
+    options.offset = req.query.offset || 0;
+    delete queryParams.offset;
+
+    // @ts-ignore
+    options.order = UtilityService.isJson(req.query.order) ? JSON.parse(req.query.order) : null;
+    delete queryParams.order;
+
+    if (TypeService.isArray(options.order) === false) {
+        delete options.order;
+    }
+
+    GamerRelationshipController.queryGamerRelationships(queryParams, options).then((gamerRelationships) => {
+        if (gamerRelationships.length > 0) {
+            responseHandler.handleResponse(req, res, gamerRelationships);
+        } else {
+            responseHandler.handleError(req, res, '', 204);
+        }
+    }).catch((error) => {
+        console.log('error', error);
+
+        responseHandler.handleError(req, res, error, 500);
+    });
+}
+
+
+
+export default {
+    queryGamerRelationships
+};

--- a/lib/components/GamerRelationships/GamerRelationshipService.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipService.ts
@@ -1,0 +1,2 @@
+export * from './../../../src/components/GamerRelationships/GamerRelationshipService';
+export {default} from './../../../src/components/GamerRelationships/GamerRelationshipService';

--- a/lib/components/GamerRelationships/GamerRelationshipTypes.ts
+++ b/lib/components/GamerRelationships/GamerRelationshipTypes.ts
@@ -1,0 +1,1 @@
+export * from './../../../src/components/GamerRelationships/GamerRelationshipTypes';

--- a/lib/components/GamerRelationships/index.ts
+++ b/lib/components/GamerRelationships/index.ts
@@ -1,0 +1,18 @@
+import GamerRelationshipController from './GamerRelationshipController';
+export {GamerRelationshipController};
+
+
+import GamerRelationshipService from './GamerRelationshipService';
+export {GamerRelationshipService};
+
+
+import GamerRelationshipRoutes from './GamerRelationshipRoutes';
+export {GamerRelationshipRoutes};
+
+
+
+export default {
+    GamerRelationshipController,
+    GamerRelationshipService,
+    GamerRelationshipRoutes
+};

--- a/lib/components/Users/UserRoutes.ts
+++ b/lib/components/Users/UserRoutes.ts
@@ -153,5 +153,5 @@ export function verifyUserToken(req, res) {
 export default {
     createUser,
     login,
-
+    verifyUserToken
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -3,7 +3,8 @@ export const MATCH_DETAILS_SLEEP_TIME = 2 * 1000;
 export const TABLES = {
     GAMER_MATCHES: 'gamer_matches',
     GAMERS: 'gamers',
-    USERS: 'users'
+    USERS: 'users',
+    GAMER_RELATIONSHIPS: 'gamer_relationships'
 };
 
 export const VIEWS = {

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -1,3 +1,4 @@
+import {createGamerRelationship} from '../lib/components/GamerRelationships/GamerRelationshipRoutes';
 const logger = require('tracer').colorConsole();
 
 const express = require('express');
@@ -29,6 +30,7 @@ export function include(server) {
     router.get('/api/gamer-match', GamerMatchRoutes.queryGamerMatches)
 
     router.get('/api/v1/gamer-relationship', GamerRelationshipRoutes.queryGamerRelationships);
+    router.post('/api/v1/gamer-relationship', GamerRelationshipRoutes.createGamerRelationship);
 
     router.post('/api/users', Users.createUser);
 

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -7,6 +7,7 @@ const Squads = require('./directories/Squads');
 
 const MatchRoutes = require('./../lib/components/Matches/MatchRoutes');
 const GamerMatchRoutes = require('./../lib/components/GamerMatches/GamerMatchRoutes');
+const GamerRelationshipRoutes = require('./../lib/components/GamerRelationships/GamerRelationshipRoutes');
 const Users = require('./../lib/components/Users/UserRoutes');
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
@@ -26,6 +27,8 @@ export function include(server) {
     router.get('/api/match', MatchRoutes.queryMatches)
 
     router.get('/api/gamer-match', GamerMatchRoutes.queryGamerMatches)
+
+    router.get('/api/v1/gamer-relationship', GamerRelationshipRoutes.queryGamerRelationships);
 
     router.post('/api/users', Users.createUser);
 

--- a/server.ts
+++ b/server.ts
@@ -7,7 +7,7 @@ const path = require('path');
 let server = express();
 
 import {generateNextConfig} from './config/server/nextConfig';
-import createAPIEventMiddleware from "./routes/siteTrafficMiddlware";
+import createAPIEventMiddleware from './routes/siteTrafficMiddlware';
 
 const dev = (process.env.NODE_ENV !== 'production');
 const CONSTANTS = {
@@ -20,7 +20,7 @@ let PORT = process.env.PORT || CONSTANTS.UNSECURED_PORT || 3000;
 const app = generateNextConfig({
     dev,
     directory: CONSTANTS.PAGES_DIRECTORY,
-    port: PORT
+    port: PORT,
 });
 
 const handle = app.getRequestHandler();
@@ -59,7 +59,7 @@ function run() {
                     }
                     next();
                 });
-                server.use('*', (req, res, next) => createAPIEventMiddleware(req, res, next))
+                server.use('*', (req, res, next) => createAPIEventMiddleware(req, res, next));
                 server.get('*', (req, res) => {
                     return handle(req, res);
                 });

--- a/src/assets/styles/appComponents.scss
+++ b/src/assets/styles/appComponents.scss
@@ -403,6 +403,35 @@ main.main {
   margin-bottom: 15px;
 }
 
+.gamer-card.clickable:hover .card-body {
+  background: #303f56;
+}
+
+.gamer-card.clickable:hover .card-header {
+  background: darken(#303f56, 5);
+}
+
+.gamer-card.clickable:active .card-body {
+  background: darken(#303f56, 5);
+}
+
+.gamer-card.clickable:active .card-header {
+  background: darken(#303f56, 10);
+}
+
+.gamer-card.condensed {
+
+}
+
+.gamer-card.condensed .card-header {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.gamer-card.condensed .card-header .gamer-link-container {
+  margin-right: 5px;
+}
+
 .gamer-card .card-header {
   font-size: 1.1em;
 }

--- a/src/components/GamerRelationships/GamerRelationshipService.tsx
+++ b/src/components/GamerRelationships/GamerRelationshipService.tsx
@@ -1,0 +1,57 @@
+import StorageService from './../Storage/StorageService';
+import HttpService from '../../services/HttpService';
+
+import {GamerRelationship, RawGamerRelationship, GamerRelationshipList} from './GamerRelationshipTypes';
+import UtilityService from '../../services/UtilityService';
+
+//===---==--=-=--==---===----===---==--=-=--==---===----//
+
+
+export function createGamerRelationship(gamerRelationship: Partial<RawGamerRelationship>): Promise<GamerRelationship> {
+    return new Promise((resolve, reject) => {
+        HttpService.http({
+            method: 'POST',
+            url: '/api/v1/gamer-relationship',
+            body: {
+                gamerRelationship
+            }
+        }).then((response) => {
+            if (response.status === 200) {
+                resolve(response.data);
+            } else {
+                reject(response);
+            }
+        }).catch(reject);
+    });
+}
+
+
+export function sanitizeGamerRelationship(gamerRelationship) {
+    return gamerRelationship;
+}
+
+
+
+export function queryGamerRelationships(query: Record<any, unknown>, options?: Record<any, unknown>): Promise<GamerRelationshipList> {
+    return new Promise((resolve, reject) => {
+        HttpService.http({
+            method: 'GET',
+            url: '/api/v1/gamer-relationship',
+            query
+        }).then((response) => {
+            if ([200, 204].includes(response.status)) {
+                resolve(UtilityService.validateItem(response.data, 'array', []).map(sanitizeGamerRelationship));
+            } else {
+                reject(response);
+            }
+        }).catch(reject);
+    });
+}
+
+
+
+export default {
+    createGamerRelationship,
+    sanitizeGamerRelationship,
+    queryGamerRelationships
+};

--- a/src/components/GamerRelationships/GamerRelationshipService.tsx
+++ b/src/components/GamerRelationships/GamerRelationshipService.tsx
@@ -31,6 +31,16 @@ export function sanitizeGamerRelationship(gamerRelationship) {
 }
 
 
+export function isValidType(type) {
+    return getValidTypes().includes(type);
+}
+
+
+export function getValidTypes() {
+    return ['self', 'friend'];
+}
+
+
 
 export function queryGamerRelationships(query: Record<any, unknown>, options?: Record<any, unknown>): Promise<GamerRelationshipList> {
     return new Promise((resolve, reject) => {
@@ -53,5 +63,7 @@ export function queryGamerRelationships(query: Record<any, unknown>, options?: R
 export default {
     createGamerRelationship,
     sanitizeGamerRelationship,
-    queryGamerRelationships
+    queryGamerRelationships,
+    isValidType,
+    getValidTypes
 };

--- a/src/components/GamerRelationships/GamerRelationshipTypes.ts
+++ b/src/components/GamerRelationships/GamerRelationshipTypes.ts
@@ -1,0 +1,30 @@
+import {Metadata} from '../Metadata/MetadataTypes';
+import {GamerPlatform, GamerUsername} from '../gamer/GamerTypes';
+import {UserID} from '../Users/UserTypes';
+
+//===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
+
+
+
+export type GamerRelationshipMetadata = Metadata & {}
+
+export type RawGamerRelationship = {
+    user_id: UserID,
+    platform: GamerPlatform
+    username: GamerUsername,
+    type: 'self' | 'friend',
+    is_favorite: boolean,
+    metadata: GamerRelationshipMetadata | String
+};
+
+
+export type RawGamerRelationshipList = RawGamerRelationship[];
+
+
+export type GamerRelationship = RawGamerRelationship & {
+    password: null,
+    metadata: GamerRelationshipMetadata
+};
+
+
+export type GamerRelationshipList = GamerRelationship[];

--- a/src/components/GamerRelationships/index.ts
+++ b/src/components/GamerRelationships/index.ts
@@ -1,0 +1,7 @@
+import GamerRelationshipService from './GamerRelationshipService';
+export {GamerRelationshipService};
+
+
+export default {
+    GamerRelationshipService
+};

--- a/src/components/app-components/Navbar.tsx
+++ b/src/components/app-components/Navbar.tsx
@@ -62,6 +62,10 @@ class Navbar extends React.Component {
 
 
                         <Show show={userIsLoggedIn}>
+                            <a href={'/dashboard'} style={{marginRight: '15px'}}>
+                                Dashboard
+                            </a>
+
                             <Button type={'secondary'} style={{fontWeight: 500}} onClick={() => {
                                 UserService.logout();
                                 Router.push('/?logout=true');

--- a/src/components/app-components/Navbar.tsx
+++ b/src/components/app-components/Navbar.tsx
@@ -27,7 +27,6 @@ class Navbar extends React.Component {
         const props = this.props;
 
         let userIsLoggedIn = UserService.userIsLoggedIn();
-        let user = userIsLoggedIn ? UserService.getUser() : {};
 
         return (
             <Box id={'navbar'} className={'navbar'} style={props['style']}>
@@ -49,11 +48,11 @@ class Navbar extends React.Component {
 
                     <Box className={'navbar-items'} id={'navbar-right'}>
                         <Show show={userIsLoggedIn !== true}>
-                            <a href={'/login'}>
+                            <a href={'/login'} id={'login-button'}>
                                 Log In
                             </a>
 
-                            <a href={'/signup'}>
+                            <a href={'/signup'} id={'signup-button'}>
                                 <Button type={'secondary'} style={{fontWeight: 500}}>
                                     Sign Up
                                 </Button>
@@ -61,12 +60,12 @@ class Navbar extends React.Component {
                         </Show>
 
 
-                        <Show show={userIsLoggedIn}>
-                            <a href={'/dashboard'} style={{marginRight: '15px'}}>
+                        <Show show={userIsLoggedIn === true}>
+                            <a href={'/dashboard'} id={'dashboard-button'} style={{marginRight: '15px'}}>
                                 Dashboard
                             </a>
 
-                            <Button type={'secondary'} style={{fontWeight: 500}} onClick={() => {
+                            <Button type={'secondary'} id={'logout-button'} style={{fontWeight: 500}} onClick={() => {
                                 UserService.logout();
                                 Router.push('/?logout=true');
                             }}>

--- a/src/components/app-components/Page.tsx
+++ b/src/components/app-components/Page.tsx
@@ -25,8 +25,6 @@ class Page extends React.Component<PageProps, PageState> {
         if (this.props.loginRequired) {
             this._redirectIfUserIsNotLoggedIn();
         }
-
-
     }
 
 

--- a/src/components/gamer/GamerAdd.tsx
+++ b/src/components/gamer/GamerAdd.tsx
@@ -17,7 +17,7 @@ const CONFIG = {
 
 type GamerAddProps = {
     recaptchaSiteKey: string,
-    baseUrl: string
+    baseUrl?: string
 }
 
 export default function GamerAdd({recaptchaSiteKey, baseUrl}: GamerAddProps) {
@@ -58,7 +58,7 @@ export default function GamerAdd({recaptchaSiteKey, baseUrl}: GamerAddProps) {
             setMessage({message: '', type: ''});
 
             const response = await HttpService.http({
-                url: baseUrl + '/api/gamer',
+                url: (baseUrl || '') + '/api/gamer',
                 method: 'POST',
                 body: {
                     username: newUserConfig.username,

--- a/src/components/gamer/GamerCard.tsx
+++ b/src/components/gamer/GamerCard.tsx
@@ -4,6 +4,7 @@ import {
     Card,
     CardBody,
     Button,
+    Show,
     CardHeader,
     Box
 } from '../SimpleComponents';
@@ -22,74 +23,103 @@ import {UserService} from '../Users';
 
 export type GamerCardProps = {
     gamer: Gamer,
-    classDescriptions?: object
+    classDescriptions?: object,
+    mode?: null | 'condensed',
+    onGamerClick?: (gamer) => void
 }
 
 
-export default function GamerCard({gamer, classDescriptions}: GamerCardProps) {
+export default function GamerCard({gamer, classDescriptions, mode, onGamerClick}: GamerCardProps) {
     let overallWinRate = (TypeService.isNumeric(gamer.win_percentage)) ? gamer.win_percentage.toFixed(2) + '%' : '-';
     let gamesPlayed = (Number(gamer.total_kills) / Number(gamer.avg_kills)).toFixed(0);
 
+    const isCondensed = mode === 'condensed';
+    const modeClass = isCondensed ? 'condensed' : 'standard';
+
+    const noLink = !!onGamerClick;
+    const cardClickable = !!noLink;
+
     // const userIsLoggedIn = UserService.userIsLoggedIn();
 
+    if (isCondensed) {
+        return getCondensedCard();
+    } else {
+        return (
+            <Card className={'gamer-card ' + modeClass}>
 
-    return (
-        <Card className={'gamer-card'}>
+                <CardHeader>
 
-            <CardHeader>
+                    <Box style={{display: 'flex', flexFlow: 'row wrap', justifyContent: 'space-between'}}>
+                        <Box style={{width: '85%'}}>
+                            <GamerLinkList gamer={gamer} noLink={noLink}/>
+                        </Box>
 
-                <Box style={{display: 'flex', flexFlow: 'row wrap', justifyContent: 'space-between'}}>
-                    <Box style={{width: '85%'}}>
-                        <GamerLinkList gamer={gamer}/>
+                        <Box style={{width: '10%'}}>
+                            {/*{getCardOptions()}*/}
+                        </Box>
                     </Box>
 
-                    <Box style={{width: '10%'}}>
-                        {/*{getCardOptions()}*/}
+                    <GamerAliasList gamer={gamer}/>
+
+                    <GamerHeat gamer={gamer}/>
+
+                    <ClassBadgeList subject={gamer as object}
+                                    classDescriptions={classDescriptions}/>
+
+                </CardHeader>
+
+                <CardBody>
+
+                    <Box className={'details'}>
+
+                        <LabelValue label={'KDR'} value={gamer.kdr}/>
+
+                        <LabelValue label={'Max Kills'} value={gamer.max_kills}/>
+
+                        <LabelValue label={'Overall Win Rate'} value={overallWinRate}/>
+
+                        <LabelValue label={'Total Games'} value={gamesPlayed}/>
+
+                        <LabelValue label={'Gulag Win Rate'}
+                                    value={gamer.gulag_win_rate}/>
+
                     </Box>
-                </Box>
 
-                <GamerAliasList gamer={gamer}/>
-
-                <GamerHeat gamer={gamer}/>
-
-                <ClassBadgeList subject={gamer as object}
-                                classDescriptions={classDescriptions}/>
-
-            </CardHeader>
-
-            <CardBody>
-
-                <Box className={'details'}>
-
-                    <LabelValue label={'KDR'} value={gamer.kdr}/>
-
-                    <LabelValue label={'Max Kills'} value={gamer.max_kills}/>
-
-                    <LabelValue label={'Overall Win Rate'} value={overallWinRate}/>
-
-                    <LabelValue label={'Total Games'} value={gamesPlayed}/>
-
-                    <LabelValue label={'Gulag Win Rate'} value={gamer.gulag_win_rate}/>
-
-                </Box>
-
-            </CardBody>
-        </Card>
-    );
+                </CardBody>
+            </Card>
+        );
+    }
 
 
-    // function getCardOptions() {
-    //     if (userIsLoggedIn) {
-    //         return (
-    //             <>
-    //                 <Button type={'link'}
-    //                         onClick={() => {
-    //
-    //                         }}>
-    //                 &#8230;
-    //             </Button>
-    //             </>
-    //         );
-    //     }
-    // }
+
+    function getCondensedCard() {
+        return (
+            <Card className={'gamer-card ' + modeClass} onClick={onGamerClick && function () {
+                onGamerClick(gamer);
+            }}>
+                <CardHeader>
+                    <GamerLinkList gamer={gamer} noLink={noLink}/>
+
+                    <GamerAliasList gamer={gamer}/>
+                </CardHeader>
+
+                <CardBody style={{paddingTop: '5px', paddingBottom: '5px'}}>
+                    <Box className={'details'} style={{paddingTop: '5px'}}>
+
+                        <LabelValue size={'sm'} label={'KDR'} value={gamer.kdr}/>
+
+                        <LabelValue size={'sm'} label={'Max Kills'} value={gamer.max_kills}/>
+
+                        <LabelValue size={'sm'} label={'Overall Win Rate'} value={overallWinRate}/>
+
+                        <LabelValue size={'sm'} label={'Total Games'} value={gamesPlayed}/>
+
+                        <LabelValue size={'sm'} label={'Gulag Win Rate'}
+                                    value={gamer.gulag_win_rate}/>
+
+                    </Box>
+                </CardBody>
+            </Card>
+        );
+    }
 }

--- a/src/components/gamer/GamerCardList.tsx
+++ b/src/components/gamer/GamerCardList.tsx
@@ -10,16 +10,24 @@ import {GamerList, Gamer} from './GamerTypes';
 
 //===---==--=-=--==---===----===---==--=-=--==---===----//
 
+type GamerCardListProps = {
+    gamers?: GamerList,
+    onGamerClick?: (gamer) => void,
+    mode?: null | 'condensed',
+    classDescriptions?: object
+};
 
-export default function GamerCardList(props: { gamers?: GamerList, gamer?: Gamer, block?: boolean, noLink?: boolean }) {
-    let {gamers} = props;
 
+export default function GamerCardList(props: GamerCardListProps) {
     return (
         <Box className={'gamer-card-list-container'}>
             {
-                gamers.map((gamer) => {
+                props.gamers.map((gamer) => {
                     return (
                         <GamerCard key={gamer.username + '-' + gamer.platform}
+                                   onGamerClick={props.onGamerClick}
+                                   mode={props.mode}
+                                   classDescriptions={props.classDescriptions}
                                    gamer={gamer}/>
                     );
                 })

--- a/src/components/gamer/GamerCardList.tsx
+++ b/src/components/gamer/GamerCardList.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {Box} from './../SimpleComponents';
+
+import TypeService from '../../services/TypeService';
+
+import GamerCard from './GamerCard';
+
+import {GamerList, Gamer} from './GamerTypes';
+
+//===---==--=-=--==---===----===---==--=-=--==---===----//
+
+
+export default function GamerCardList(props: { gamers?: GamerList, gamer?: Gamer, block?: boolean, noLink?: boolean }) {
+    let {gamers} = props;
+
+    return (
+        <Box className={'gamer-card-list-container'}>
+            {
+                gamers.map((gamer) => {
+                    return (
+                        <GamerCard key={gamer.username + '-' + gamer.platform}
+                                   gamer={gamer}/>
+                    );
+                })
+            }
+        </Box>
+    );
+}

--- a/src/components/gamer/GamerSearchInput.tsx
+++ b/src/components/gamer/GamerSearchInput.tsx
@@ -1,0 +1,47 @@
+import React, {useState} from 'react';
+
+import {Box, Container} from './../SimpleComponents';
+
+import TypeService from '../../services/TypeService';
+
+import GamerLink from './GamerLink';
+
+import GamerCardList from './GamerCardList';
+import {GamerList, Gamer} from './GamerTypes';
+import {Input} from '../SmartComponents';
+
+//===---==--=-=--==---===----===---==--=-=--==---===----//
+
+
+export default function GamerSearchInput(props: { size: 'xl' | 'lg' | 'md' | 'sm', baseUrl?: string, focus: boolean }) {
+    let {size, baseUrl, focus} = props;
+    const [gamerResults, setGamerResults] = useState([]);
+
+
+
+    const searchGamers = async (inputValue) => {
+        if (inputValue && inputValue.length > 1) {
+            const dataUrl = (baseUrl || '') + '/api/gamer?username.ilike=' + encodeURIComponent('%' + inputValue + '%');
+            const response = await fetch(dataUrl);
+            const newGamers = await response.json();
+            setGamerResults(newGamers.gamers);
+        } else {
+            setGamerResults([]);
+        }
+    };
+
+
+
+    return (
+        <Box className={'gamer-search-container'}>
+            <Input onChange={searchGamers}
+                   placeholder={'Search Gamers'}
+                   mode={'plain'}
+                   focus={focus === true}
+                   inputStyle={{borderRadius: 0, borderBottom: '1px solid #888'}}
+                   size={size}/>
+
+            <GamerCardList gamers={gamerResults}/>
+        </Box>
+    );
+}

--- a/src/components/gamer/GamerSearchInput.tsx
+++ b/src/components/gamer/GamerSearchInput.tsx
@@ -12,11 +12,19 @@ import {Input} from '../SmartComponents';
 
 //===---==--=-=--==---===----===---==--=-=--==---===----//
 
+type GamerSearchInputProps = {
+    size: 'xl' | 'lg' | 'md' | 'sm',
+    baseUrl?: string,
+    focus?: boolean,
+    mode?: null | 'condensed',
+    onGamerClick?: (gamer) => void
+}
 
-export default function GamerSearchInput(props: { size: 'xl' | 'lg' | 'md' | 'sm', baseUrl?: string, focus: boolean }) {
+export default function GamerSearchInput(props: GamerSearchInputProps) {
     let {size, baseUrl, focus} = props;
     const [gamerResults, setGamerResults] = useState([]);
 
+    const gamerClickMethodExists = TypeService.isFunction(props.onGamerClick);
 
 
     const searchGamers = async (inputValue) => {
@@ -41,7 +49,9 @@ export default function GamerSearchInput(props: { size: 'xl' | 'lg' | 'md' | 'sm
                    inputStyle={{borderRadius: 0, borderBottom: '1px solid #888'}}
                    size={size}/>
 
-            <GamerCardList gamers={gamerResults}/>
+            <GamerCardList gamers={gamerResults}
+                           mode={props.mode}
+                           onGamerClick={props.onGamerClick}/>
         </Box>
     );
 }

--- a/src/components/gamer/index.ts
+++ b/src/components/gamer/index.ts
@@ -2,6 +2,10 @@ import GamerCard from './GamerCard';
 export {GamerCard};
 
 
+import GamerCardList from './GamerCardList';
+export {GamerCardList};
+
+
 import GamerGradeChart from './GamerGradeChart';
 export {GamerGradeChart};
 
@@ -30,6 +34,10 @@ import GamerPlatformImage from './GamerPlatformImage';
 export {GamerPlatformImage};
 
 
+import GamerSearchInput from './GamerSearchInput';
+export {GamerSearchInput};
+
+
 import GamerService from './GamerService';
 export {GamerService};
 
@@ -48,16 +56,18 @@ export {GamerAdd};
 
 
 export default {
-    GamerCard: GamerCard,
-    GamerGradeChart: GamerGradeChart,
-    GamerPlacementChart: GamerPlacementChart,
-    GamerAliasList: GamerAliasList,
-    GamerHeat: GamerHeat,
-    GamerLink: GamerLink,
-    GamerLinkList: GamerLinkList,
-    GamerPlatformImage: GamerPlatformImage,
-    GamerService: GamerService,
-    GamerTimeChart: GamerTimeChart,
-    TeammateTable: TeammateTable,
-    GamerAdd: GamerAdd
+    GamerCard,
+    GamerCardList,
+    GamerGradeChart,
+    GamerPlacementChart,
+    GamerAliasList,
+    GamerHeat,
+    GamerLink,
+    GamerLinkList,
+    GamerPlatformImage,
+    GamerSearchInput,
+    GamerService,
+    GamerTimeChart,
+    TeammateTable,
+    GamerAdd
 };

--- a/src/components/simple-components/Button.tsx
+++ b/src/components/simple-components/Button.tsx
@@ -39,6 +39,7 @@ const Button = (props: ButtonProps) => {
 
     return (
         <button {...props}
+                id={props.id}
                 className={classNames}
                 type={buttonType}
                 style={props.style}
@@ -63,11 +64,12 @@ export default Button;
 const TS_VALID_TYPES = [...Object.keys(CONSTANTS.VALID_TYPES)] as const;
 
 type ButtonProps = {
-    onClick?:  (ButtonProps, any) => void,
+    onClick?: (ButtonProps, any) => void,
     className?: string,
     style?: React.CSSProperties,
     children?: React.ReactNode | React.ReactNodeArray,
     innerRef?: any,
+    id?: string,
     buttonType?: (typeof CONSTANTS.VALID_BUTTON_TYPES) | string,
     noDefaultType?: boolean,
     block?: boolean,

--- a/src/components/simple-components/Card.tsx
+++ b/src/components/simple-components/Card.tsx
@@ -6,11 +6,15 @@ const Card = (props: CardProps) => {
     const classNames = getClassNames(props);
 
     return (
-        <div {...props} className={classNames} style={props.style} ref={props.innerRef} onClick={() => {
-            if (props.onClick) {
-                props.onClick();
-            }
-        }}>
+        <div {...props}
+             className={classNames}
+             style={props.style}
+             ref={props.innerRef}
+             onClick={() => {
+                 if (props.onClick) {
+                     props.onClick();
+                 }
+             }}>
             {props.children}
         </div>
     );
@@ -28,7 +32,7 @@ type CardProps = {
     children?: React.ReactNode | React.ReactNodeArray,
     innerRef?: any,
     shadow?: 1 | 2 | 3 | 4 | 5,
-    onClick?:  () => void
+    onClick?: () => void
 }
 
 
@@ -44,7 +48,7 @@ function getClassNames(props) {
         classNames.push(props.className);
     }
 
-    if (props.onClick) {
+    if (!!props.onClick) {
         classNames.push('clickable');
     }
 

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useEffect, Component} from 'react';
 import {useRouter} from 'next/router';
+import dynamic from 'next/dynamic';
 
 import {Navbar, Page, Footer, GamerCard} from './../components/AppComponents';
 import {
@@ -17,23 +18,27 @@ import {
     Text,
     Small,
     Main,
-    LineBreak, UnorderedList, ListItem
+    LineBreak, UnorderedList, ListItem, Show
 } from './../components/SimpleComponents';
-import {Input} from './../components/SmartComponents';
+import {Input, LabelValue, Sidebar, SidebarCompanion} from './../components/SmartComponents';
 
 import CONSTANTS from './../config/CONSTANTS';
 
 import {UserService} from './../components/Users';
-import UtilityService, {getBaseUrlWithProtocol} from '../services/UtilityService';
-import TypeService from '../services/TypeService';
+import {GamerRelationshipService} from './../components/GamerRelationships';
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
 
 
 let DashboardPage = ({baseUrl}) => {
-
     let router = useRouter();
+
     let user = UserService.getUser();
+
+    useEffect(() => {
+        getData();
+    });
+
     console.log(user);
 
     return (
@@ -41,11 +46,24 @@ let DashboardPage = ({baseUrl}) => {
             <Navbar/>
 
             <Main>
-                <Container size={'sm'}>
+                <Container size={'lg'} mode={'sidebar'}>
 
-                    <Header>Hello, {user && user.first_name}</Header>
+                    <Sidebar>
+                        <Header>{user.first_name}</Header>
 
-                    <Paragraph>Content Coming Soon</Paragraph>
+                        <LineBreak/>
+
+
+                    </Sidebar>
+
+
+
+                    <SidebarCompanion>
+
+
+
+                    </SidebarCompanion>
+
                 </Container>
             </Main>
 
@@ -54,7 +72,23 @@ let DashboardPage = ({baseUrl}) => {
     );
 
 
+
+    function getData() {
+        getGamerRelationships();
+    }
+
+
+
+    function getGamerRelationships() {
+        GamerRelationshipService.queryGamerRelationships({
+            user_id: user.user_id
+        }).then((gamerRelationships) => {
+            console.log('gamerRelationships', gamerRelationships);
+        }).catch((error) => {
+            console.error(error);
+        });
+    }
 };
 
 
-export default DashboardPage;
+export default dynamic(() => Promise.resolve(DashboardPage), {ssr: false});

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -3,6 +3,7 @@ import {useRouter} from 'next/router';
 import dynamic from 'next/dynamic';
 
 import {Navbar, Page, Footer, GamerCard} from './../components/AppComponents';
+
 import {
     Container,
     Header,
@@ -20,12 +21,14 @@ import {
     Main,
     LineBreak, UnorderedList, ListItem, Show
 } from './../components/SimpleComponents';
+
 import {Input, LabelValue, Sidebar, SidebarCompanion} from './../components/SmartComponents';
 
 import CONSTANTS from './../config/CONSTANTS';
 
 import {UserService} from './../components/Users';
 import {GamerRelationshipService} from './../components/GamerRelationships';
+import {GamerSearchInput} from '../components/gamer';
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
 
@@ -33,11 +36,28 @@ import {GamerRelationshipService} from './../components/GamerRelationships';
 let DashboardPage = ({baseUrl}) => {
     let router = useRouter();
 
-    let user = UserService.getUser();
+    let [hasMounted, setHasMounted] = useState(false);
+    let [loading, setLoading] = useState(true);
+    let [dataHasLoaded, setDataHasLoaded] = useState(false);
+    let [error, setError] = useState(null);
+
+    let [user, setUser] = useState(null);
+    let [gamerRelationships, setGamerRelationships] = useState([]);
+
+    hasMounted === false && setHasMounted(true);
 
     useEffect(() => {
-        getData();
-    });
+        if (UserService.userIsLoggedIn()) {
+            setUser(UserService.getUser());
+        }
+    }, [hasMounted]);
+
+    useEffect(() => {
+        if (user && dataHasLoaded === false) {
+            console.log('user is logged in');
+            getData();
+        }
+    }, [user]);
 
     console.log(user);
 
@@ -47,23 +67,7 @@ let DashboardPage = ({baseUrl}) => {
 
             <Main>
                 <Container size={'lg'} mode={'sidebar'}>
-
-                    <Sidebar>
-                        <Header>{user.first_name}</Header>
-
-                        <LineBreak/>
-
-
-                    </Sidebar>
-
-
-
-                    <SidebarCompanion>
-
-
-
-                    </SidebarCompanion>
-
+                    {getContent()}
                 </Container>
             </Main>
 
@@ -73,19 +77,56 @@ let DashboardPage = ({baseUrl}) => {
 
 
 
+    function getContent() {
+        if (user && loading !== true) {
+            return (
+                <>
+                    <Sidebar>
+                        <Header>{user.first_name}</Header>
+
+                        <LineBreak/>
+
+                    </Sidebar>
+
+
+
+                    <SidebarCompanion>
+
+                        <GamerSearchInput size={'lg'}
+                                          baseUrl={baseUrl}
+                                          focus={false}/>
+
+                    </SidebarCompanion>
+                </>
+            );
+        }
+    }
+
+
+
     function getData() {
-        getGamerRelationships();
+        console.log('get data');
+        getGamerRelationships().finally(() => {
+            setLoading(false);
+            setDataHasLoaded(true);
+        });
     }
 
 
 
     function getGamerRelationships() {
-        GamerRelationshipService.queryGamerRelationships({
-            user_id: user.user_id
-        }).then((gamerRelationships) => {
-            console.log('gamerRelationships', gamerRelationships);
-        }).catch((error) => {
-            console.error(error);
+        return new Promise((resolve, reject) => {
+
+            GamerRelationshipService.queryGamerRelationships({
+                user_id: user.user_id
+            }).then((_gamerRelationships) => {
+                console.log('_gamerRelationships', _gamerRelationships);
+                setGamerRelationships(_gamerRelationships);
+                resolve();
+            }).catch((error) => {
+                console.error(error);
+                reject(error);
+            });
         });
     }
 };

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -28,7 +28,8 @@ import CONSTANTS from './../config/CONSTANTS';
 
 import {UserService} from './../components/Users';
 import {GamerRelationshipService} from './../components/GamerRelationships';
-import {GamerSearchInput} from '../components/gamer';
+import {GamerSearchInput, GamerAdd, GamerService, GamerLinkList} from '../components/gamer';
+import {Gamer} from '../components/gamer/GamerTypes';
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
 
@@ -39,10 +40,13 @@ let DashboardPage = ({baseUrl}) => {
     let [hasMounted, setHasMounted] = useState(false);
     let [loading, setLoading] = useState(true);
     let [dataHasLoaded, setDataHasLoaded] = useState(false);
+    let [newUserSearch, setNewUserSearch] = useState('search');
     let [error, setError] = useState(null);
 
     let [user, setUser] = useState(null);
     let [gamerRelationships, setGamerRelationships] = useState([]);
+    let mainGamer = gamerRelationships.length > 0 && gamerRelationships.filter(({type}) => type === 'self')[0] as Gamer;
+    console.log(mainGamer);
 
     hasMounted === false && setHasMounted(true);
 
@@ -78,6 +82,9 @@ let DashboardPage = ({baseUrl}) => {
 
 
     function getContent() {
+        const userHasNoRelationships = (gamerRelationships.length === 0);
+        const userHasAMain = !!mainGamer;
+
         if (user && loading !== true) {
             return (
                 <>
@@ -86,19 +93,90 @@ let DashboardPage = ({baseUrl}) => {
 
                         <LineBreak/>
 
+                        <GamerLinkList gamer={mainGamer}/>
+
                     </Sidebar>
 
 
 
                     <SidebarCompanion>
 
-                        <GamerSearchInput size={'lg'}
-                                          baseUrl={baseUrl}
-                                          focus={false}/>
+
+                        {userHasAMain && <GamerCard gamer={mainGamer}/>}
+
+                        {userHasNoRelationships && getNewUserContent()}
+
+
 
                     </SidebarCompanion>
                 </>
             );
+        }
+    }
+
+
+
+    function getNewUserContent() {
+
+        return (
+            <>
+                <Header size={'lg'}>
+                    Welcome to BR Shooter
+                </Header>
+
+                <Paragraph>
+                    To get started, you'll need to select your main Warzone account to track. You'll only be able to track 1 account as your main, but you can add friends and favorites later.
+                </Paragraph>
+
+                <Show show={newUserSearch === 'search'}>
+                    <Paragraph>
+                        If you account is already in our system, you can search for it below, or <a
+                        onClick={() => setNewUserSearch(newUserSearch === 'search' ? 'create' : 'search')}>
+                        you can add your new account and we'll start tracking your stats right away</a>
+                    </Paragraph>
+
+                    <GamerSearchInput size={'lg'}
+                                      baseUrl={baseUrl}
+                                      mode={'condensed'}
+                                      onGamerClick={newUserGamerSelect}
+                                      focus={false}/>
+                </Show>
+
+                <Show show={newUserSearch === 'create'}>
+                    <Paragraph>
+                        You can add your gamer details, or <a
+                        onClick={() => setNewUserSearch(newUserSearch === 'search' ? 'create' : 'search')}>
+                        if your account is already in our system, you can search for it here
+                    </a>
+                    </Paragraph>
+
+                    <GamerAdd recaptchaSiteKey={process.env.NEXT_PUBLIC_WARZONE_RECAPTCHA_SITE_KEY}/>
+                </Show>
+            </>
+        );
+    }
+
+
+
+    function newUserGamerSelect(gamer) {
+        if (gamer) {
+            const {username, platform} = gamer;
+
+            let userIsOkay = confirm(`select OK to make ${username} (${GamerService.getPlatformObjByID(platform).name}) your main`);
+
+            if (userIsOkay) {
+                GamerRelationshipService.createGamerRelationship({
+                    user_id: user.user_id,
+                    username: username,
+                    platform: platform,
+                    type: 'self'
+                }).then((gamerRelationship) => {
+                    console.log(gamerRelationship);
+                    getGamerRelationships();
+                }).catch((error) => {
+                    console.log(error);
+                });
+            }
         }
     }
 

--- a/src/pages/gamers/index.tsx
+++ b/src/pages/gamers/index.tsx
@@ -10,6 +10,7 @@ import {SidebarCompanion, Input, Sidebar} from '../../components/SmartComponents
 import UtilityService, {getBaseUrlWithProtocol} from '../../services/UtilityService';
 
 import {GamerCard, GamerAdd} from './../../components/gamer/index';
+import GamerCardList from '../../components/gamer/GamerCardList';
 
 //===---==--=-=--==---===----===---==--=-=--==---===----//
 
@@ -83,15 +84,19 @@ export default function Gamers({gamers, baseUrl, recaptchaSiteKey, sort, usernam
                                         loader={<div className="loader" key={0}>Loading ...</div>}
                                         useWindow={true}>
 
-                            {
-                                gamerValues.map((gamer) => {
-                                    return (
-                                        <GamerCard key={gamer.username + '-' + gamer.platform}
-                                                   gamer={gamer}
-                                                   classDescriptions={classDescriptions}/>
-                                    );
-                                })
-                            }
+
+                            <GamerCardList gamers={gamerValues}
+                                           classDescriptions={classDescriptions}/>
+
+                            {/*{*/}
+                            {/*    gamerValues.map((gamer) => {*/}
+                            {/*        return (*/}
+                            {/*            <GamerCard key={gamer.username + '-' + gamer.platform}*/}
+                            {/*                       gamer={gamer}*/}
+                            {/*                       classDescriptions={classDescriptions}/>*/}
+                            {/*        );*/}
+                            {/*    })*/}
+                            {/*}*/}
 
                         </InfiniteScroll>
                     </SidebarCompanion>

--- a/src/pages/gamers/index.tsx
+++ b/src/pages/gamers/index.tsx
@@ -87,17 +87,7 @@ export default function Gamers({gamers, baseUrl, recaptchaSiteKey, sort, usernam
 
                             <GamerCardList gamers={gamerValues}
                                            classDescriptions={classDescriptions}/>
-
-                            {/*{*/}
-                            {/*    gamerValues.map((gamer) => {*/}
-                            {/*        return (*/}
-                            {/*            <GamerCard key={gamer.username + '-' + gamer.platform}*/}
-                            {/*                       gamer={gamer}*/}
-                            {/*                       classDescriptions={classDescriptions}/>*/}
-                            {/*        );*/}
-                            {/*    })*/}
-                            {/*}*/}
-
+                                           
                         </InfiniteScroll>
                     </SidebarCompanion>
                 </Container>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,28 +3,16 @@ import React, {useState, Component} from 'react';
 import {Navbar, Page, Footer, GamerCard} from './../components/AppComponents';
 import {Container, Header, Box, Text, Small, Main, LineBreak, Button} from './../components/SimpleComponents';
 import {Input} from './../components/SmartComponents';
-import {GetServerSideProps} from "next";
-import {getBaseUrlWithProtocol} from "../services/UtilityService";
+import {GetServerSideProps} from 'next';
+import {getBaseUrlWithProtocol} from '../services/UtilityService';
+
+import {GamerSearchInput} from './../components/gamer';
 
 //===----=---=-=--=--===--=-===----=---=-=--=--===--=-===----=---=-=--=--===--=-//
 
 
 const Home = ({baseUrl}) => {
     const [searchInputValue, updateSearchInputValue] = useState('');
-    const [gamerResults, setGamerResults] = useState([]);
-
-    const searchGamers = async (inputValue) => {
-        if(inputValue.length > 1){
-            const dataUrl = baseUrl + '/api/gamer?username.ilike=' + encodeURIComponent('%' + inputValue + '%');
-            const response = await fetch(dataUrl);
-            const newGamers = await response.json();
-            setGamerResults(newGamers.gamers);
-        }
-        else{
-            setGamerResults([]);
-        }
-    };
-    let gamerCards = gamerResults.map((gamer) => <GamerCard gamer={gamer} classDescriptions={{}}/>)
 
     return (
         <Page title={'Warzone'}>
@@ -45,14 +33,9 @@ const Home = ({baseUrl}) => {
 
                         <LineBreak clear/>
 
-                        <Input onChange={searchGamers}
-                               placeholder={'Search Gamers'}
-                               mode={'plain'}
-                               focus
-                               inputStyle={{borderRadius: 0, borderBottom: '1px solid #888'}}
-                               size={'xl'}
-                        />
-                        {gamerCards}
+                        <GamerSearchInput focus={true}
+                                          size={'xl'}
+                                          baseUrl={baseUrl}/>
                     </Container>
 
                 </Box>
@@ -94,7 +77,7 @@ const Home = ({baseUrl}) => {
             <Footer/>
         </Page>
     );
-}
+};
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
     const baseUrl = getBaseUrlWithProtocol(context.req);

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -97,8 +97,8 @@ let LoginPage = ({baseUrl}) => {
             <Navbar/>
 
             <Main>
-                <Container size={'sm'} style={{maxWidth: '600px'}}>
-                    <Card style={{marginTop: '20px', marginBottom: '100px'}}>
+                <Container size={'sm'} style={{maxWidth: '600px',  paddingBottom: '100px'}}>
+                    <Card style={{marginTop: '20px', marginBottom: '20px'}}>
                         <CardHeader>
                             <Header>Log In</Header>
 
@@ -146,6 +146,10 @@ let LoginPage = ({baseUrl}) => {
                             </Box>
                         </CardFooter>
                     </Card>
+
+                    <Paragraph>
+                        If you don't have an account, you can <a href={'/signup'}>sign up here for free</a>
+                    </Paragraph>
 
                 </Container>
             </Main>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -123,15 +123,13 @@ let SignUpPage = ({baseUrl}) => {
 
                             <Paragraph type={'help'}>
                                 Signing up for an account will give you insight to your gameplay, friend tracking, and
-                                personalized recommendations to improve your Warzone performance. <Text bold>You will be
-                                                                                                             able to add
-                                                                                                             and manage
-                                                                                                             your
-                                                                                                             Warzone
-                                                                                                             accounts
-                                                                                                             when you
-                                                                                                             log
-                                                                                                             in.</Text>
+                                personalized recommendations to improve your Warzone performance. <Text bold>
+                                You will be able to add and manage your Warzone accounts when you log in.
+                            </Text>
+                            </Paragraph>
+
+                            <Paragraph>
+                                If you already have an account, <a href={'/login'}>log in here</a>
                             </Paragraph>
 
                             <Alert hideIfEmpty={true} type={formMessage.type}>


### PR DESCRIPTION
- Create user
- Logged in dashboard does a redirect if you're not logged in
- Search for gamers and click to confirm the "self" relationship, where you mark that gamer as your main account
- Created a condensed view for the gamer card and gamer card list
- Created an onGamerClick feature for the gamer card and gamer list so we can click on the whole card instead of just having a link to the gamer
- Create and query gamer relationships

NOTES
- Add username/platform doesn't connect anything up, yet, so we need to link it in
- No good data is being displayed, simply that the relationship exists when you click on the user in the search
   - We need to figure out how to display some good info on the dashboard based on the gamer relationships, maybe we could get and save the gamer-relationships to localstorage when the user logs in so we can easily find them