### PR TITLE
Gamer Detail: Team Type Breakdown Details

### DIFF
--- a/lib/components/Utils.ts
+++ b/lib/components/Utils.ts
@@ -6,6 +6,7 @@ export function getQueryParamToSQLMap() {
         'teammates': VIEWS.GAMER_INFLUENCE_RELATIONSHIPS,
         'placements': VIEWS.GRADED_STATS,
         'stats': VIEWS.GRADED_STATS,
+        'overview': VIEWS.GRADED_STATS,
         'time': VIEWS.TIME_ANALYSIS,
         'squads': VIEWS.SQUADS,
         'trends': VIEWS.TREND_ANALYSIS,

--- a/lib/sql/views/core/gamer_rolling_trends.sql
+++ b/lib/sql/views/core/gamer_rolling_trends.sql
@@ -33,7 +33,26 @@ WITH valid_users AS (
                 CAST(AVG(CASE WHEN gulag_kills >= 1 then 1 else 0 end)
                      OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_rolling_average_gulag_kills,
                 CAST(AVG(CASE WHEN gulag_deaths >= 1 then 1 else 0 end)
-                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_rolling_average_gulag_deaths
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_rolling_average_gulag_deaths,
+
+                CAST(AVG(CASE WHEN team_type = 'solo' THEN kills end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_solo_rolling_average_kills,
+                CAST(AVG(CASE WHEN team_type = 'duo' THEN kills end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_duo_rolling_average_kills,
+                CAST(AVG(CASE WHEN team_type = 'trio' THEN kills end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_trio_rolling_average_kills,
+                CAST(AVG(CASE WHEN team_type = 'quad' THEN kills end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_quad_rolling_average_kills,
+
+                CAST(AVG(CASE WHEN team_type = 'solo' THEN deaths end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_solo_rolling_average_deaths,
+                CAST(AVG(CASE WHEN team_type = 'duo' THEN deaths end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_duo_rolling_average_deaths,
+                CAST(AVG(CASE WHEN team_type = 'trio' THEN deaths end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_trio_rolling_average_deaths,
+                CAST(AVG(CASE WHEN team_type = 'quad' THEN deaths end)
+                     OVER (PARTITION BY gm.query_platform, gm.query_username, game_category ORDER BY m.start_time ROWS BETWEEN 99 PRECEDING AND CURRENT ROW ) AS REAL) AS last_100_quad_rolling_average_deaths,
+
          FROM warzone.gamer_matches gm
                   JOIN warzone.matches m on m.match_id = gm.match_id
                   JOIN valid_users v ON gm.query_username = v.query_username and gm.query_platform = v.query_platform
@@ -46,6 +65,16 @@ WITH valid_users AS (
                      NULLIF(last_30_rolling_average_deaths, 0) AS REAL) AS  last_30_rolling_average_kdr,
                 CAST(last_100_rolling_average_kills /
                      NULLIF(last_100_rolling_average_deaths, 0) AS REAL) AS last_100_rolling_average_kdr,
+
+                CAST(last_100_solo_rolling_average_kills /
+                     NULLIF(last_100_solo_rolling_average_deaths, 0) AS REAL) AS last_100_solo_rolling_average_kdr,
+                CAST(last_100_duo_rolling_average_kills /
+                     NULLIF(last_100_duo_rolling_average_deaths, 0) AS REAL) AS last_100_duo_rolling_average_kdr,
+                CAST(last_100_trio_rolling_average_kills /
+                     NULLIF(last_100_trio_rolling_average_deaths, 0) AS REAL) AS last_100_trio_rolling_average_kdr,
+                CAST(last_100_quad_rolling_average_kills /
+                     NULLIF(last_100_quad_rolling_average_deaths, 0) AS REAL) AS last_100_quad_rolling_average_kdr,
+
                 CAST((last_10_rolling_average_kills + (last_10_rolling_average_assists / 2)) /
                      NULLIF(last_10_rolling_average_deaths, 0) AS REAL) AS  last_10_rolling_average_kadr,
                 CAST((last_30_rolling_average_kills + (last_30_rolling_average_assists / 2)) /

--- a/lib/sql/views/core/gamer_stat_summary.sql
+++ b/lib/sql/views/core/gamer_stat_summary.sql
@@ -46,10 +46,49 @@ WITH agg AS (
            NULLIF(COUNT(DISTINCT CASE WHEN team_type = 'quad' THEN m.match_id END), 0) AS quad_win_rate,
 
 
+           AVG(CASE WHEN team_type = 'solo' THEN gm.team_placement END)                AS avg_solo_placement,
+           AVG(CASE WHEN team_type = 'duo' THEN gm.team_placement END)                 AS avg_duo_placement,
            AVG(CASE WHEN team_type = 'trio' THEN gm.team_placement END)                AS avg_trio_placement,
            AVG(CASE WHEN team_type = 'quad' THEN gm.team_placement END)                AS avg_quad_placement,
-           AVG(CASE WHEN team_type = 'duo' THEN gm.team_placement END)                 AS avg_duo_placement,
-           AVG(CASE WHEN team_type = 'solo' THEN gm.team_placement END)                AS avg_solo_placement,
+
+
+           count(CASE WHEN team_type = 'solo' THEN m.match_id end)  as solo_match_count,
+           count(CASE WHEN team_type = 'duo' THEN m.match_id end)  as duo_match_count,
+           count(CASE WHEN team_type = 'trio' THEN m.match_id end)  as trio_match_count,
+           count(CASE WHEN team_type = 'quad' THEN m.match_id end)  as quad_match_count,
+
+
+           count(CASE WHEN team_type = 'solo' AND team_placement = 1 then m.match_id END) AS solo_wins,
+           count(CASE WHEN team_type = 'duo' AND team_placement = 1 then m.match_id END) AS duo_wins,
+           count(CASE WHEN team_type = 'trio' AND team_placement = 1 then m.match_id END) AS trio_wins,
+           count(CASE WHEN team_type = 'quad' AND team_placement = 1 then m.match_id END) AS quad_wins,
+
+
+           CAST(COUNT(CASE WHEN team_type = 'solo' AND team_placement <= 10 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'solo' then m.match_id END)), 0)    AS solo_top_10_rate,
+           CAST(COUNT(CASE WHEN team_type = 'duo' AND team_placement <= 10 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'duo' then m.match_id END)), 0)    AS duo_top_10_rate,
+           CAST(COUNT(CASE WHEN team_type = 'trio' AND team_placement <= 10 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'trio' then m.match_id END)), 0)    AS trio_top_10_rate,
+           CAST(COUNT(CASE WHEN team_type = 'quad' AND team_placement <= 10 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'quad' then m.match_id END)), 0)    AS quad_top_10_rate,
+
+
+           CAST(COUNT(CASE WHEN team_type = 'solo' AND team_placement <= 15 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'solo' then m.match_id END)), 0)    AS solo_top_10_percent_rate,
+           CAST(COUNT(CASE WHEN team_type = 'duo' AND team_placement <= 8 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'duo' then m.match_id END)), 0)    AS duo_top_10_percent_rate,
+           CAST(COUNT(CASE WHEN team_type = 'trio' AND team_placement <= 5 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'trio' then m.match_id END)), 0)    AS trio_top_10_percent_rate,
+           CAST(COUNT(CASE WHEN team_type = 'quad' AND team_placement <= 4 THEN m.match_id END) AS REAL) /
+           NULLIF(COUNT(DISTINCT (case when team_type = 'quad' then m.match_id END)), 0)    AS quad_top_10_percent_rate,
+
+
+           CAST(MAX(CASE WHEN team_type = 'solo' THEN kills END) AS INTEGER)    AS solo_max_kills,
+           CAST(MAX(CASE WHEN team_type = 'duo' THEN kills END) AS INTEGER)    AS duo_max_kills,
+           CAST(MAX(CASE WHEN team_type = 'trio' THEN kills END) AS INTEGER)    AS trio_max_kills,
+           CAST(MAX(CASE WHEN team_type = 'quad' THEN kills END) AS INTEGER)    AS quad_max_kills,
+
            COUNT(1)                                                                    AS num_matches
 
     FROM warzone.gamer_matches gm
@@ -63,16 +102,22 @@ SELECT a.*,
        COALESCE(ghr.last_10_rolling_average_kdr, a.kdr)  as last_10_rolling_average_kdr,
        COALESCE(ghr.last_30_rolling_average_kdr, a.kdr)  AS last_30_rolling_average_kdr,
        COALESCE(ghr.last_100_rolling_average_kdr, a.kdr) AS last_100_rolling_average_kdr,
+
+       COALESCE(ghr.last_100_solo_rolling_average_kdr, a.kdr) AS last_100_solo_rolling_average_kdr,
+       COALESCE(ghr.last_100_duo_rolling_average_kdr, a.kdr) AS last_100_duo_rolling_average_kdr,
+       COALESCE(ghr.last_100_trio_rolling_average_kdr, a.kdr) AS last_100_trio_rolling_average_kdr,
+       COALESCE(ghr.last_100_quad_rolling_average_kdr, a.kdr) AS last_100_quad_rolling_average_kdr,
+
        COALESCE(ghr.last_10_rolling_average_kadr, a.kdr)  as last_10_rolling_average_kadr,
        COALESCE(ghr.last_30_rolling_average_kadr, a.kdr)  AS last_30_rolling_average_kadr,
        COALESCE(ghr.last_100_rolling_average_kadr, a.kdr) AS last_100_rolling_average_kadr,
        COALESCE(ghr.last_100_rolling_average_gulag_kdr, a.kdr) AS last_100_rolling_average_gulag_kdr,
        CONCAT(a.username, '-', a.platform)               as platform_username,
-       COALESCE(ghr.heat_score, 0) as heat_score
+       COALESCE(ghr.heat_index_10_100, 0) as heat_score
 FROM agg a
          LEFT JOIN warzone.gamer_rolling_trends ghr
                    ON a.username = ghr.query_username
                        AND a.platform = ghr.query_platform
                        AND ghr.game_category = a.game_category
                        AND ghr.is_latest_game = TRUE
-    );
+    )

--- a/routes/directories/Gamers.ts
+++ b/routes/directories/Gamers.ts
@@ -155,19 +155,25 @@ async function updateGamerUponRequest(gamer: Gamer) {
 export async function getGamerDetails(req: NextApiRequest & { params: { username: string, platform: string } }, res: NextApiResponse) {
     const {view, game_category} = req.query;
     delete req.query.view;
+
     const {username, platform} = req.params;
+
     let allParams = {...req.params, ...req.query};
 
     let paramMap = getQueryParamToSQLMap();
+
     let errorObject = {
         'missing_data': 'platform and username (/gamers/:platform/:username, String) are required and cannot be empty',
         'invalid_view': 'invalid view query param needs to be in ' + Object.keys(paramMap).join(','),
         'not_found': username + ' on platform: ' + platform + ' was not found!'
     };
+
     if (!platform || !username) {
         return handleError(req, res, {message: errorObject['missing_data']});
     }
+
     const sqlView = paramMap[view as string];
+
     if (!sqlView) {
         return handleError(req, res, {message: errorObject['invalid_view']});
     }
@@ -184,11 +190,13 @@ export async function getGamerDetails(req: NextApiRequest & { params: { username
     const viewData = viewToQuery.data;
 
     await updateGamerUponRequest(gamer);
+
     const seoMetadata = {
         title: 'Warzone stats for ' + gamer['username'],
         keywords: ['warzone', 'stats', 'kdr', 'gulag wins'],
         description: 'KDR: ' + gamer['kdr'] + ' Gulag Win Rate: ' + gamer['gulag_win_rate']
     };
+
     handleResponse(req, res, {
         gamer,
         viewData,

--- a/src/pages/gamer/[platform]/[username].tsx
+++ b/src/pages/gamer/[platform]/[username].tsx
@@ -1,6 +1,15 @@
 import {GetServerSideProps} from 'next';
 import React, {useEffect, useState} from 'react';
-import {Box, Button, Container, Header, LineBreak, Main, Small} from './../../../components/SimpleComponents';
+import {
+    Box,
+    Button,
+    Paragraph,
+    Container,
+    Header,
+    LineBreak,
+    Main,
+    Small
+} from './../../../components/SimpleComponents';
 import {LabelValue, Sidebar, SidebarCompanion, StatLabelValue, TabNav} from '../../../components/SmartComponents';
 import {
     ClassBadgeList,
@@ -28,6 +37,58 @@ import {GamerService} from '../../../components/gamer';
 
 const CONFIG = {
     VIEW_NAME_CONFIG: {
+        // overview: (gamer, chartState) => {
+        //     console.log(gamer);
+        //
+        //     return (
+        //         <Box>
+        //             <Header size={'md'}>Overall</Header>
+        //
+        //             <LabelValue label={'Average Placement'} value={UtilityService.round(gamer.avg_placement, 1)}/>
+        //
+        //
+        //             <Header size={'md'}>Solos</Header>
+        //
+        //             <LabelValue label={'Average Placement'} value={UtilityService.round(gamer.avg_solo_placement, 1)}/>
+        //
+        //             <LabelValue label={'Win Rate'} value={UtilityService.numberToPercentage(gamer.solo_win_rate, 1)}/>
+        //
+        //             <Header size={'md'}>Duos</Header>
+        //
+        //             <LabelValue label={'Average Placement'} value={UtilityService.round(gamer.avg_duo_placement, 1)}/>
+        //
+        //             <LabelValue label={'Win Rate'} value={UtilityService.numberToPercentage(gamer.duo_win_rate, 1)}/>
+        //
+        //
+        //             <Header size={'md'}>Trios</Header>
+        //
+        //             <LabelValue label={'Average Placement'} value={UtilityService.round(gamer.avg_trio_placement, 1)}/>
+        //
+        //             <LabelValue label={'Win Rate'} value={UtilityService.numberToPercentage(gamer.trio_win_rate, 1)}/>
+        //
+        //
+        //             <Header size={'md'}>Quads</Header>
+        //
+        //             <LabelValue label={'Average Placement'} value={UtilityService.round(gamer.avg_quad_placement, 1)}/>
+        //
+        //             <LabelValue label={'Win Rate'} value={UtilityService.numberToPercentage(gamer.quad_win_rate, 1)}/>
+        //
+        //
+        //             <LabelValue label={'Matches'} value={UtilityService.numberToPercentage(gamer.quad_match_count, 1)}/>
+        //
+        //             <LabelValue label={'Wins'} value={UtilityService.numberToPercentage(gamer.quad_wins, 1)}/>
+        //
+        //             <LabelValue label={'Top 10 Rate'} value={UtilityService.numberToPercentage(gamer.quad_top_10_rate, 1)}/>
+        //
+        //             <LabelValue label={'Top 10% Rate'} value={UtilityService.numberToPercentage(gamer.quad_top_10_percent_rate, 1)}/>
+        //
+        //             <LabelValue label={'Last 100 KDR'} value={UtilityService.numberToPercentage(gamer.last_100_quad_rolling_kdr, 1)}/>
+        //
+        //             <LabelValue label={'Max Kills'} value={UtilityService.numberToPercentage(gamer.quad_max_kills, 1)}/>
+        //         </Box>
+        //     );
+        // },
+
         teammates: (gamer, chartState) => <GamerInfluenceList gamer={gamer}
                                                               teammateRows={chartState.viewData}/>,
 
@@ -69,15 +130,14 @@ export default function GamerDetail({gamerData, view, gameCategory, baseUrl, err
     }
     const {gamer, viewData, errorMessage, classDescriptions} = gamerData;
 
-    const tabNames = Object.keys(CONFIG.VIEW_NAME_CONFIG).filter((key)=>{
-        const allowableUnoKeys = ['squads', 'trends', 'recent_matches']
-        if(gamer.platform == 'uno'){
+    const tabNames = Object.keys(CONFIG.VIEW_NAME_CONFIG).filter((key) => {
+        const allowableUnoKeys = ['squads', 'trends', 'recent_matches'];
+        if (gamer.platform == 'uno') {
             return allowableUnoKeys.includes(key);
-        }
-        else{
+        } else {
             return true;
         }
-    })
+    });
 
 
     const tabOptions = tabNames.map((id) => {
@@ -145,7 +205,7 @@ export default function GamerDetail({gamerData, view, gameCategory, baseUrl, err
         let username = '';
         if (gamer) {
             username = gamer.username;
-            if(gamer.platform == 'uno'){
+            if (gamer.platform == 'uno') {
                 username = gamer.aliases[0] + '#' + gamer.username.substring(0, 6);
             }
         }
@@ -288,9 +348,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const validViewNames = Object.keys(CONFIG.VIEW_NAME_CONFIG);
     const queryCategory = game_category || GAME_CATEGORIES.WARZONE;
     let defaultView = 'teammates';
-    if(platform == 'uno'){
+
+    if (platform == 'uno') {
         defaultView = 'recent_matches';
     }
+
     const selectedView = validViewNames.includes(view as string) ? context.query.view : defaultView;
     const baseUrl = getBaseUrlWithProtocol(context.req);
     const rawGamerList = await GamerService.getGamerDetailView(username as string,


### PR DESCRIPTION
Started on a feature to display a breakdown of the different team structures and how the user performed, but couldn't get very far when I realized the db has been migrated. @EcZachly, could you do a big favor for me and integrate these view changes with your changes when the db migration is complete?

I want to have these details for each of the following team types
- last_100_[team type]_rolling_average_kills
- last_100_[team type]_rolling_average_deaths
- last_100_[team type]_rolling_average_kdr
- [team type]_match_count
- [team type]_wins
- [team type]_top_10_rate (all just placing above 10)
- [team type]_top_10_percent_rate (solos is better than 15, duos is better than 8, trios is better than 5, and quads is better than 4)
- [team type]_max_kills

I've hidden the UI changes for now until we can get the new views in place